### PR TITLE
fix

### DIFF
--- a/Safe/src/org/openintents/safe/AskPassword.java
+++ b/Safe/src/org/openintents/safe/AskPassword.java
@@ -96,6 +96,10 @@ public class AskPassword extends DistributionLibraryActivity {
 	private MediaPlayer mpSuccessBeep = null;
 	private boolean mute=false;
 	
+	private Toast blankPasswordToast = null;
+	private Toast invalidPasswordToast = null;
+	private Toast confirmPasswordFailToast = null;
+	
 	/** Called when the activity is first created. */
 	@Override
 	public void onCreate(Bundle icicle) {
@@ -153,6 +157,10 @@ public class AskPassword extends DistributionLibraryActivity {
 		} else {
 			keypadInit();
 		}
+		
+		blankPasswordToast = Toast.makeText(AskPassword.this, R.string.notify_blank_pass, Toast.LENGTH_SHORT);
+		invalidPasswordToast = Toast.makeText(AskPassword.this, R.string.invalid_password, Toast.LENGTH_SHORT);
+		confirmPasswordFailToast = Toast.makeText(AskPassword.this, R.string.confirm_pass_fail, Toast.LENGTH_SHORT);
 	}
 
 	private void normalInit() {
@@ -232,8 +240,7 @@ public class AskPassword extends DistributionLibraryActivity {
 		// Password must be at least 4 characters
 		if (PBEKey.length() < 4) {
 			pbeKey.setText("");
-			Toast.makeText(AskPassword.this, R.string.notify_blank_pass,
-					Toast.LENGTH_SHORT).show();
+			blankPasswordToast.show();
 			Animation shake = AnimationUtils
 					.loadAnimation(AskPassword.this, R.anim.shake);
 
@@ -252,9 +259,7 @@ public class AskPassword extends DistributionLibraryActivity {
 			if (pbeKey.getText().toString().compareTo(
 					confirmPass.getText().toString()) != 0) {
 				confirmPass.setText("");
-				Toast.makeText(AskPassword.this,
-						R.string.confirm_pass_fail, Toast.LENGTH_SHORT)
-						.show();
+				confirmPasswordFailToast.show();
 				Animation shake = AnimationUtils
 						.loadAnimation(AskPassword.this, R.anim.shake);
 
@@ -287,8 +292,7 @@ public class AskPassword extends DistributionLibraryActivity {
 			// Check the user's password and display a
 			// message if it's wrong
 			pbeKey.setText("");
-			Toast.makeText(AskPassword.this, R.string.invalid_password,
-					Toast.LENGTH_SHORT).show();
+			invalidPasswordToast.show();
 			Animation shake = AnimationUtils
 					.loadAnimation(AskPassword.this, R.anim.shake);
 
@@ -327,6 +331,13 @@ public class AskPassword extends DistributionLibraryActivity {
 
 		if (debug) Log.d(TAG, "onPause()");
 
+		if (blankPasswordToast != null)
+			blankPasswordToast.cancel();
+		if (invalidPasswordToast != null)
+			invalidPasswordToast.cancel();
+		if (confirmPasswordFailToast != null)
+			confirmPasswordFailToast.cancel();
+	
 		if (dbHelper!=null) {
 			dbHelper.close();
 			dbHelper = null;


### PR DESCRIPTION
This contains a patch for Issue 516 which describes how toasts are displayed even when the user exits the application.

The reason for that is that the Toasts are created using Toast.makeText and in order to hide/dismiss them, the cancel method needs to be called in the onPause() method.
I've thus created instance variables for the Toast and then called the show() and cancel() methods on them at the appropriate time.

Please review the patch and let me know whether any changes are required to be done.
