### PR TITLE
Numeric Keypad with UK regionalisation not equally spaced

### DIFF
--- a/Safe/res/layout-small/keypad.xml
+++ b/Safe/res/layout-small/keypad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
 * $Id$
 * 
 * Copyright (C) 2009 OpenIntents.org
@@ -15,113 +15,174 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
+*
 -->
 
- <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:fillViewport="true"
-	android:scrollbars="vertical">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fillViewport="true"
+    android:scrollbars="vertical" >
 
-<LinearLayout
-	android:orientation="vertical"
-	android:layout_width="fill_parent"
-	android:layout_height="wrap_content">
-	<LinearLayout 
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:orientation="horizontal">
-		<TextView android:id="@+id/entry_header"
-			android:layout_width="wrap_content" 
-			android:layout_height="wrap_content" 
-			android:text="@string/app_name"
-			android:paddingTop="10dp"
-			android:textSize="24dp"
-			android:gravity="center"
-			android:layout_gravity="center"
-			android:drawableLeft="@drawable/ic_launcher_safe"
-			/>
-		<LinearLayout
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:orientation="horizontal"
-			android:gravity="right">
-			<ImageView android:id="@+id/switch_button"
-				android:layout_gravity="right"
-				android:layout_height="48dp"
-				android:layout_width="48dp"
-				android:src="@android:drawable/ic_menu_directions"
-				android:contentDescription="@string/switch_mode"
-				/>
-		</LinearLayout>
-	</LinearLayout>
-	<TableLayout
-		android:layout_width="fill_parent"
-		android:layout_height="fill_parent"
-		android:gravity="center"
-		android:stretchColumns="0,1,2">
-		<TableRow>
-			<Button android:id="@+id/keypad1"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/one" />
-			<Button android:id="@+id/keypad2"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/two" />
-			<Button android:id="@+id/keypad3"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/three" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad4"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/four" />
-			<Button android:id="@+id/keypad5"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/five" />
-			<Button android:id="@+id/keypad6"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/six" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad7"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/seven" />
-			<Button android:id="@+id/keypad8"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/eight" />
-			<Button android:id="@+id/keypad9"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/nine" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad_star"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/asterisk" />
-			<Button android:id="@+id/keypad0"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/zero" />
-			<Button android:id="@+id/keypad_pound"
-				android:padding="10sp"
-				android:textSize="30sp"
-				android:text="@string/numbersign" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad_continue"
-				android:layout_span="3"
-				android:text="@string/continue_text" />
-		</TableRow>
-	</TableLayout>
-</LinearLayout>
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/entry_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:drawableLeft="@drawable/ic_launcher_safe"
+                android:gravity="center"
+                android:paddingTop="10dp"
+                android:text="@string/app_name"
+                android:textSize="24dp" />
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="right"
+                android:orientation="horizontal" >
+
+                <ImageView
+                    android:id="@+id/switch_button"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="right"
+                    android:contentDescription="@string/switch_mode"
+                    android:src="@android:drawable/ic_menu_directions" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TableLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:gravity="center"
+            android:stretchColumns="0,1,2" >
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad1"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/one"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad2"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/two"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad3"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/three"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad4"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/four"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad5"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/five"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad6"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/six"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad7"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/seven"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad8"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/eight"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad9"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/nine"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad_star"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/asterisk"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad0"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/zero"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad_pound"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="10sp"
+                    android:text="@string/numbersign"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad_continue"
+                    android:layout_span="3"
+                    android:text="@string/continue_text" />
+            </TableRow>
+        </TableLayout>
+    </LinearLayout>
+
 </ScrollView>

--- a/Safe/res/layout/keypad.xml
+++ b/Safe/res/layout/keypad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
 * $Id$
 * 
 * Copyright (C) 2009 OpenIntents.org
@@ -15,113 +15,174 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
+*
 -->
 
- <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:fillViewport="true"
-	android:scrollbars="vertical">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fillViewport="true"
+    android:scrollbars="vertical" >
 
-<LinearLayout
-	android:orientation="vertical"
-	android:layout_width="fill_parent"
-	android:layout_height="wrap_content">
-	<LinearLayout 
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:orientation="horizontal">
-		<TextView android:id="@+id/entry_header"
-			android:layout_width="wrap_content" 
-			android:layout_height="wrap_content"
-			android:layout_gravity="center_horizontal" 
-			android:text="@string/app_name"
-			android:paddingTop="10dp"
-			android:textSize="24dp"
-			android:gravity="center_horizontal"
-			android:drawableLeft="@drawable/ic_launcher_safe"
-			/>
-		<LinearLayout
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:orientation="horizontal"
-			android:gravity="right">
-			<ImageView android:id="@+id/switch_button"
-				android:layout_gravity="right"
-				android:layout_height="48dp"
-				android:layout_width="48dp"
-				android:src="@android:drawable/ic_menu_directions"
-				android:contentDescription="@string/switch_mode"
-				/>
-		</LinearLayout>
-	</LinearLayout>
-	<TableLayout
-		android:layout_width="fill_parent"
-		android:layout_height="fill_parent"
-		android:gravity="center"
-		android:stretchColumns="0,1,2">
-		<TableRow>
-			<Button android:id="@+id/keypad1"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/one" />
-			<Button android:id="@+id/keypad2"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/two" />
-			<Button android:id="@+id/keypad3"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/three" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad4"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/four" />
-			<Button android:id="@+id/keypad5"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/five" />
-			<Button android:id="@+id/keypad6"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/six" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad7"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/seven" />
-			<Button android:id="@+id/keypad8"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/eight" />
-			<Button android:id="@+id/keypad9"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/nine" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad_star"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/asterisk" />
-			<Button android:id="@+id/keypad0"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/zero" />
-			<Button android:id="@+id/keypad_pound"
-				android:padding="20sp"
-				android:textSize="30sp"
-				android:text="@string/numbersign" />
-		</TableRow>
-		<TableRow>
-			<Button android:id="@+id/keypad_continue"
-				android:layout_span="3"
-				android:text="@string/continue_text" />
-		</TableRow>
-	</TableLayout>
-</LinearLayout>
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/entry_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:drawableLeft="@drawable/ic_launcher_safe"
+                android:gravity="center_horizontal"
+                android:paddingTop="10dp"
+                android:text="@string/app_name"
+                android:textSize="24dp" />
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="right"
+                android:orientation="horizontal" >
+
+                <ImageView
+                    android:id="@+id/switch_button"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="right"
+                    android:contentDescription="@string/switch_mode"
+                    android:src="@android:drawable/ic_menu_directions" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TableLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:gravity="center"
+            android:stretchColumns="0,1,2" >
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad1"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/one"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad2"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/two"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad3"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/three"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad4"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/four"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad5"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/five"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad6"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/six"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad7"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/seven"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad8"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/eight"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad9"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/nine"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad_star"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/asterisk"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad0"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/zero"
+                    android:textSize="30sp" />
+
+                <Button
+                    android:id="@+id/keypad_pound"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:padding="20sp"
+                    android:text="@string/numbersign"
+                    android:textSize="30sp" />
+            </TableRow>
+
+            <TableRow>
+
+                <Button
+                    android:id="@+id/keypad_continue"
+                    android:layout_weight="1"
+                    android:text="@string/continue_text" />
+            </TableRow>
+        </TableLayout>
+    </LinearLayout>
+
 </ScrollView>


### PR DESCRIPTION
When set to UK region the keypad shows No. rather than #. This causes the right hand column of buttons to be larger than the other two.

I have created a pull request from andrew-codechimp/safe which fixes the normal layout and layout-small variants. The landscape version was not effected by this.
