### PR TITLE
Autobackup prompt limiter

### DIFF
--- a/Safe/build.gradle
+++ b/Safe/build.gradle
@@ -25,7 +25,7 @@ android {
     sourceSets {
 
         // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
+        androidTest.setRoot('tests')
 
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
@@ -49,8 +49,10 @@ android {
 
             applicationVariants.all { variant ->
                 variant.outputs.each { output ->
+                    def relativeRootDir = output.packageApplication.outputDirectory.toPath()
+                            .relativize(rootDir.toPath()).toFile()
                     def file = output.outputFile
-                    output.outputFileName = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
+                    output.outputFileName = new File("$relativeRootDir/release", file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
                 }
             }
         }
@@ -88,21 +90,21 @@ play {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+    implementation fileTree(dir: 'libs', include: '*.jar')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    compile 'com.github.openintents:distribution:3.0.1'
-    compile 'com.jakewharton:butterknife:8.5.1'
+    implementation 'com.github.openintents:distribution:3.0.1'
+    implementation 'com.jakewharton:butterknife:8.5.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
-    compile 'com.android.support:support-annotations:27.1.0'
-    compile 'com.android.support:support-fragment:27.1.0'
-    compile 'com.android.support:preference-v7:27.1.0'
-    compile 'com.android.support:design:27.1.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'com.android.support:support-fragment:28.0.0'
+    implementation 'com.android.support:preference-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
 
-    androidTestCompile 'com.android.support:support-annotations:27.1.0'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test:rules:1.0.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-    androidTestCompile "com.android.support.test.espresso:espresso-intents:3.0.1"
+    androidTestImplementation 'com.android.support:support-annotations:28.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation "com.android.support.test.espresso:espresso-intents:3.0.2"
 }
 repositories {
     mavenCentral()

--- a/Safe/src/main/java/org/openintents/safe/AskPassword.java
+++ b/Safe/src/main/java/org/openintents/safe/AskPassword.java
@@ -149,6 +149,10 @@ public class AskPassword extends DistributionLibraryActivity {
             switch (dbHelper.fetchVersion()) {
                 case 2:
                     databaseVersionError();
+                    break;
+                case 4:
+                    dbHelper.updateDbVersion4to5();
+                    break;
             }
         }
         dbSalt = dbHelper.fetchSalt();

--- a/Safe/src/main/res/layout/pass_edit_fragment.xml
+++ b/Safe/src/main/res/layout/pass_edit_fragment.xml
@@ -128,6 +128,7 @@
       android:layout_width="fill_parent"
       android:layout_height="0dip"
       android:layout_weight="1"
+      android:minHeight="100dp"
       android:gravity="top"
       android:hint="@string/notes"
       android:inputType="textMultiLine"

--- a/SafeDemo/build.gradle
+++ b/SafeDemo/build.gradle
@@ -41,8 +41,10 @@ android {
 
             applicationVariants.all { variant ->
                 variant.outputs.each { output ->
+                    def relativeRootDir = output.packageApplication.outputDirectory.toPath()
+                            .relativize(rootDir.toPath()).toFile()
                     def file = output.outputFile
-                    output.outputFileName = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
+                    output.outputFileName = new File("$relativeRootDir/release", file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
                 }
             }
         }
@@ -72,5 +74,5 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.71'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -25,9 +25,9 @@ ext {
     versionCode = versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
     versionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 
-    compileSdkVersion = 27
-    buildToolsVersion = "27.0.3"
-    targetSdkVersion = 27
+    compileSdkVersion = 28
+    buildToolsVersion = "28.0.3"
+    targetSdkVersion = 28
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 15 16:40:57 CET 2018
+#Tue Oct 30 10:19:33 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
User would like to ensure that changes to their password list are persisted in a backup file asap.
Autobackup can be a nuisance when no changes have been made but the prompt comes up as scheduled.
If we set a flag to only allow the autobackup prompt when something has changed in the password list, we get the best of both worlds, ensuring timely backups but not being pestered when there's nothing to back up.
This PR also has the updates for the build scripts to the latest versions, and one small UI change to increase the size of the Notes section while editing.